### PR TITLE
Implemented code for an already existing "compress" option in method `.to_ww3()`

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,7 +2,7 @@ numpy
 pandas
 xarray==0.11.3
 python-dateutil
-dask>=0.17.1
+dask==1.2.2
 toolz
 sortedcontainers
 scipy

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 numpy
 pandas
-xarray>=0.16.1
+xarray==0.11.3
 python-dateutil
 dask>=0.17.1
 toolz

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,4 +1,5 @@
 netCDF4==1.5.3
+mpmath==1.1.0
 sympy==1.5.1
 dbfread
 matplotlib

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,4 +1,4 @@
-netCDF4==1.5.5
+netCDF4==1.5.3
 sympy==3.0.13
 dbfread
 matplotlib

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,4 +1,4 @@
 netCDF4==1.5.3
-sympy==3.0.13
+sympy==1.5.1
 dbfread
 matplotlib

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,4 +1,4 @@
-netCDF4
-sympy
+netCDF4==1.5.5
+sympy==3.0.13
 dbfread
 matplotlib


### PR DESCRIPTION
The main reason for this **pull_request** is to merge changes done in file `wavespectra/output/ww3.py`, where the code for the already existing 'compress' option was implemented i.e. option existed but nothing in this regard was being done. The method however was always returning a compressed file when saving a initially loaded WW3 file format into WW3 file format again, that is because all the encodings from the original WW3 (i.e. compressed!) netcdf loaded was being carried over into the the output file generated by the method. This was causing some issues down the track in the SCHISM Wrapper workflow, mainly because decompressing the "huge" WW3 spectra file was slowing down pre-process significantly. The default for option 'compress' remains the same so no backward incompatibilities are expected to other code bases that uses this method.

Since the SCHISM Wrapper was only supporting python 2 at the time, we had to downgrade version of some specific libraries, see files:

    - requirements/default.txt
    - requirements/extra.txt

The idea is that after the pull_request is approved for changes done on file `wavespectra/output/ww3.py`, I will "revert" the version downgrades mentioned above...
