### PR TITLE
update of 'xarray.ufuncs' syntax

### DIFF
--- a/wavespectra/construct/specconstruct.py
+++ b/wavespectra/construct/specconstruct.py
@@ -136,9 +136,9 @@ def calc_Sf_ochihubble(freqs, hs, fp, lam):
     """
     w = 2 * np.pi * freqs
     w0 = 2 * np.pi * fp
-    B = xr.ufuncs.maximum(lam, 0.01) + 0.25
+    B = xr.apply_ufunc(np.maximum, lam, 0.01) + 0.25
     A = 0.5 * np.pi * hs ** 2 * ((B * w0 ** 4) ** lam / gamma_fun(lam))
-    a = xr.ufuncs.minimum((w0 / w) ** 4, 100.0)
+    a = xr.apply_ufunc(np.minimum, (w0 / w) ** 4, 100.0)
     Sf = A * np.exp(-B * a) / (w ** (4.0 * B))
     return Sf.fillna(0)
 

--- a/wavespectra/core/misc.py
+++ b/wavespectra/core/misc.py
@@ -76,8 +76,9 @@ def uv_to_spddir(u, v, coming_from=False):
     ang_rot = 180 if coming_from else 0
     vetor = u + v * 1j
     mag = np.abs(vetor)
-    direc = xr.ufuncs.angle(vetor, deg=True) + ang_rot
+    direc = xr.apply_ufunc(np.angle, vetor.values, True) + ang_rot
     direc = np.mod(90 - direc, 360)
+    direc = vetor.copy(data=direc)
     return mag, direc
 
 

--- a/wavespectra/specdataset.py
+++ b/wavespectra/specdataset.py
@@ -6,6 +6,7 @@ import types
 import warnings
 
 import six
+import numpy as np
 import xarray as xr
 
 from wavespectra.core.attributes import attrs
@@ -144,7 +145,7 @@ class SpecDataset(object):
         lons = self.dset[attrs.LONNAME].values
         lats = self.dset[attrs.LATNAME].values
         xdist0 = abs(lons % 360 - lon % 360)
-        xdist = xr.ufuncs.minimum(xdist0, 360 - xdist0)
+        xdist = xr.apply_ufunc(np.minimum, xdist0, 360-xdist0)
         ydist = abs(lats - lat)
         dist2 = xdist ** 2 + ydist ** 2
         isite = [int(dist2.argmin())]


### PR DESCRIPTION
Recent `xarray` versions (not sure from which version exactly) no longer has numpy methods embedded in `xarray.ufuncs`, instead, numpy methods must be provided as argument to `xarray_apply_ufunc` - see example below:

old syntax:

> B = xr.ufuncs.maximum(lam, 0.01) + 0.25

new syntax:

>B = xr.apply_ufunc(np.maximum, lam, 0.01) + 0.25


If the proposed changes are accepted, then limiting `xarray` to `<2022.06.0`  (as in [de576eb](https://github.com/metocean/wavespectra/commit/de576ebe2b95a28c8411d58513281f0b6eac7f32)) shall no longer be necessary (?)
