### PR TITLE
add read_hot_wwm reader and fix ww3 output warnings

### DIFF
--- a/wavespectra/input/wwm.py
+++ b/wavespectra/input/wwm.py
@@ -90,6 +90,73 @@ def read_wwm(filename_or_fileglob, chunks={}, convert_wind_vectors=True):
     return dset.drop_vars(to_drop).transpose(*dims)
 
 
+def read_hot_wwm(filename_or_fileglob, chunks={}, convert_wind_vectors=True):
+    """Read spectra from a WWM hotstart file (wwm_hot_out.nc).
+
+    Hotstart files differ from WWM station output: action density is stored on
+    mesh nodes (mnp dim) with integer frequency/direction index dimensions, and
+    SPSIG/SPDIR are stored as separate coordinate variables rather than dim
+    coordinates.
+
+    Args:
+        - filename_or_fileglob (str): filename or fileglob specifying multiple
+          files to read.
+        - chunks (dict): chunk sizes for dimensions in dataset. By default
+          dataset is loaded using single chunk for all dimensions (see
+          xr.open_mfdataset documentation).
+        - convert_wind_vectors (bool): choose it to convert wind vectors into
+          speed / direction data arrays.
+
+    Returns:
+        - dset (SpecDataset): spectra dataset object with standard wavespectra
+          dimensions (time, site, freq, dir).
+    """
+    dset = xr.open_mfdataset(filename_or_fileglob, chunks=chunks)
+    _units = dset.ac.attrs.get("units", "")
+    dset = dset.rename(
+        {
+            "nfreq": attrs.FREQNAME,
+            "ndir": attrs.DIRNAME,
+            "mnp": attrs.SITENAME,
+            "ac": attrs.SPECNAME,
+            "lon": attrs.LONNAME,
+            "lat": attrs.LATNAME,
+            "depth": attrs.DEPNAME,
+            "ocean_time": attrs.TIMENAME,
+        }
+    )
+    if convert_wind_vectors and "Uwind" in dset and "Vwind" in dset:
+        dset[attrs.WSPDNAME], dset[attrs.WDIRNAME] = uv_to_spddir(
+            dset["Uwind"], dset["Vwind"], coming_from=True
+        )
+    set_spec_attributes(dset)
+    dset[attrs.SPECNAME].attrs.update(
+        {"_units": _units, "_variable_name": attrs.SPECNAME}
+    )
+    dset[attrs.FREQNAME] = dset.SPSIG / (2 * np.pi)  # rad to Hz
+    dset[attrs.DIRNAME] = dset.SPDIR
+    dset[attrs.SPECNAME] = dset[attrs.SPECNAME] * dset.SPSIG * (2 * np.pi)  # action to energy
+    dset[attrs.DIRNAME] = dset[attrs.DIRNAME] * R2D  # rad to deg
+    dset[attrs.SPECNAME] /= R2D
+    dset[attrs.DIRNAME] = (270 - dset[attrs.DIRNAME] + 360) % 360  # trig to nautical
+    dset = dset.sortby(attrs.DIRNAME, ascending=True)
+    to_drop = [
+        dvar
+        for dvar in dset.data_vars
+        if dvar
+        not in [
+            attrs.SPECNAME,
+            attrs.WSPDNAME,
+            attrs.WDIRNAME,
+            attrs.DEPNAME,
+            attrs.LONNAME,
+            attrs.LATNAME,
+        ]
+    ]
+    dims = [d for d in ["time", "site", "freq", "dir"] if d in dset.efth.dims]
+    return dset.drop_vars(to_drop).transpose(*dims)
+
+
 if __name__ == "__main__":
     import os
 

--- a/wavespectra/input/wwm.py
+++ b/wavespectra/input/wwm.py
@@ -94,9 +94,9 @@ def read_hot_wwm(filename_or_fileglob, chunks={}, convert_wind_vectors=True):
     """Read spectra from a WWM hotstart file (wwm_hot_out.nc).
 
     Hotstart files differ from WWM station output: action density is stored on
-    mesh nodes (mnp dim) with integer frequency/direction index dimensions, and
-    SPSIG/SPDIR are stored as separate coordinate variables rather than dim
-    coordinates.
+    mesh nodes (mnp dim) with integer frequency/direction index dimensions.
+    Frequencies and directions are reconstructed from frlow/frhigh scalars and
+    dimension sizes rather than read from explicit SPSIG/SPDIR variables.
 
     Args:
         - filename_or_fileglob (str): filename or fileglob specifying multiple
@@ -113,6 +113,10 @@ def read_hot_wwm(filename_or_fileglob, chunks={}, convert_wind_vectors=True):
     """
     dset = xr.open_mfdataset(filename_or_fileglob, chunks=chunks)
     _units = dset.ac.attrs.get("units", "")
+    frlow = float(dset.frlow)
+    frhigh = float(dset.frhigh)
+    nfreq = dset.dims["nfreq"]
+    ndir = dset.dims["ndir"]
     dset = dset.rename(
         {
             "nfreq": attrs.FREQNAME,
@@ -133,9 +137,14 @@ def read_hot_wwm(filename_or_fileglob, chunks={}, convert_wind_vectors=True):
     dset[attrs.SPECNAME].attrs.update(
         {"_units": _units, "_variable_name": attrs.SPECNAME}
     )
-    dset[attrs.FREQNAME] = dset.SPSIG / (2 * np.pi)  # rad to Hz
-    dset[attrs.DIRNAME] = dset.SPDIR
-    dset[attrs.SPECNAME] = dset[attrs.SPECNAME] * dset.SPSIG * (2 * np.pi)  # action to energy
+    spsig = xr.DataArray(
+        frlow * (frhigh / frlow) ** (np.arange(nfreq) / (nfreq - 1)) * (2 * np.pi),
+        dims=[attrs.FREQNAME],
+    )
+    spdir = xr.DataArray(np.arange(ndir) * (2 * np.pi / ndir), dims=[attrs.DIRNAME])
+    dset[attrs.FREQNAME] = spsig / (2 * np.pi)  # rad to Hz
+    dset[attrs.DIRNAME] = spdir
+    dset[attrs.SPECNAME] = dset[attrs.SPECNAME] * spsig * (2 * np.pi)  # action to energy
     dset[attrs.DIRNAME] = dset[attrs.DIRNAME] * R2D  # rad to deg
     dset[attrs.SPECNAME] /= R2D
     dset[attrs.DIRNAME] = (270 - dset[attrs.DIRNAME] + 360) % 360  # trig to nautical

--- a/wavespectra/output/ww3.py
+++ b/wavespectra/output/ww3.py
@@ -68,8 +68,8 @@ def to_ww3(self, filename, ncformat="NETCDF4", compress=None):
                                 dims=("site", "string16"),
                             )
 
-    # Renaming variables
-    mapping = {v: k for k, v in MAPPING.items() if v in self.variables}
+    # Renaming variables (skip no-ops to avoid xarray index warning)
+    mapping = {v: k for k, v in MAPPING.items() if v in self.variables and v != k}
     other = other.rename(mapping)
 
     # Setting attributes
@@ -125,7 +125,7 @@ def to_ww3(self, filename, ncformat="NETCDF4", compress=None):
                 other[dkey].encoding["scale_factor"] = 1.0
                 other[dkey].encoding["add_offset"] = 0.0
                 ## ensure adequate missing/fillvalues
-                fillvalue =  9.96921e+36
+                fillvalue = np.float32(9.96921e+36)
                 for akey in ["missing_value", "_FillValue"]:
                     if akey not in other[dkey].encoding \
                     or other[dkey].encoding[akey] != fillvalue:
@@ -146,7 +146,7 @@ def to_ww3(self, filename, ncformat="NETCDF4", compress=None):
     elif compress is None:
         ## for backwards compatibility
         if "efth" in other and "_FillValue" not in other.efth.encoding:
-            other.efth.encoding["_FillValue"] = 9.96921e+36
+            other.efth.encoding["_FillValue"] = np.float32(9.96921e+36)
 
     # Dump file to disk
     other.to_netcdf(filename)


### PR DESCRIPTION
  - add read_hot_wwm to input/wwm.py to read WWM hotstart files (wwm_hot_out.nc), which differ from common WWM output in variable names and dimension structure (mnp nodes, integer nfreq/ndir dims, SPSIG/SPDIR coords)
  - fix no-op rename warning in output/ww3.py: skip entries where source and target name are identical to avoid xarray index deprecation warning
  - fix _FillValue cast warning in output/ww3.py: cast 9.96921e+36 to np.float32 explicitly to avoid RuntimeWarning on float64->float32 encoding